### PR TITLE
Include user/packager provided CFLAGS, CPPFLAGS, and LDFLAGS

### DIFF
--- a/src/blosc/Makefile.in
+++ b/src/blosc/Makefile.in
@@ -31,8 +31,8 @@ libH5Zblosc.so:	H5Zblosc.o
 		   libblosc.a -lz
 		  
 H5Zblosc.o: libblosc.a
-	$(CC) $(PGK_CFLAGS) $(PKG_CPICFLAGS) -c -o H5Zblosc.o H5Zblosc.c \
-	      $(PKG_CPPFLAGS) -I./lib/blosc-1.16.3
+	$(CC) $(CFLAGS) $(PGK_CFLAGS) $(PKG_CPICFLAGS) -c -o H5Zblosc.o H5Zblosc.c \
+	      $(PKG_CPPFLAGS) $(CPPFLAGS) -I./lib/blosc-1.16.3
 
 libblosc.a:  blosc
 	rm -f libblosc.a

--- a/src/bzip2/Makefile
+++ b/src/bzip2/Makefile
@@ -3,7 +3,7 @@ all: libH5Zbz2.so
 
 libH5Zbz2.so:	bzip2-1.0.8/libbz2.a
 	${CC} ${PKG_CFLAGS} ${PKG_CPICFLAGS} -shared H5Zbzip2.c $(PKG_CPPFLAGS) \
-	-I./bzip2-1.0.8/ ./bzip2-1.0.8/libbz2.a -o libH5Zbz2.so
+	-I./bzip2-1.0.8/ ./bzip2-1.0.8/libbz2.a $(LDFLAGS) -o libH5Zbz2.so
 
 bzip2-1.0.8/libbz2.a:
 	$(MAKE) -C bzip2-1.0.8


### PR DESCRIPTION
Hello,

We use this patch in the Debian package for rhdf5filters and thought it would be nice to share.

Thanks,