### PR TITLE
FIxed confgiure: Rscript should be called with `--slave`

### DIFF
--- a/configure
+++ b/configure
@@ -1987,7 +1987,7 @@ fi
 
 
 ## determine the location of the Rhdf5lib versions of the HDF5 library
-RHDF5_INCLUDE=`"${R_HOME}/bin${R_ARCH_BIN}/Rscript" -e 'cat(system.file("include", package="Rhdf5lib"))'`
+RHDF5_INCLUDE=`"${R_HOME}/bin${R_ARCH_BIN}/Rscript" --slave -e 'cat(system.file("include", package="Rhdf5lib"))'`
 
 
 echo "configuring the BLOSC filter..."


### PR DESCRIPTION
Rscript should be called with `--slave` to avoid printing R's welcome message. If not implemented, then the installation fails because RHDF5_INCLUDE includes the welcome message.  