### PR TITLE
liblzf: fix build on macOS

### DIFF
--- a/src/lzf/lzf/Makefile
+++ b/src/lzf/lzf/Makefile
@@ -6,6 +6,7 @@ all: liblzf.a
 liblzf.a: lzf_c.o lzf_d.o
 	rm -f liblzf.a
 	$(AR) cq liblzf.a lzf_c.o lzf_d.o
+	$(RANLIB) liblzf.a
 
 lzf_c.o: lzf_c.c
 	$(CC) $(FLAGS) -c lzf_c.c


### PR DESCRIPTION
At least on macOS, `ranlib` should be run on a static lib, otherwise build fails:
```
rm -f liblzf.a
ar cq liblzf.a lzf_c.o lzf_d.o
/opt/local/bin/gcc-mp-12 -pipe -Os -arch ppc -fPIC -shared H5Zlzf.c -isystem/opt/local/include/LegacySupport -I/opt/local/include -I"/opt/local/Library/Frameworks/R.framework/Versions/4.2/Resources/library/Rhdf5lib/include" \
	-I./lzf/ ./lzf/liblzf.a -Wl,-headerpad_max_install_names -Wl,-rpath,/opt/local/lib/libgcc -L/opt/local/lib -lMacportsLegacySupport -arch ppc -o libH5Zlzf.so
ld: in ./lzf/liblzf.a, archive has no table of contents
collect2: error: ld returned 1 exit status
make[1]: *** [libH5Zlzf.so] Error 1
make: *** [lzf/libH5Zlzf.so] Error 2
```